### PR TITLE
fix inline sizes

### DIFF
--- a/extensions/wishlist-page/src/WishlistItem.tsx
+++ b/extensions/wishlist-page/src/WishlistItem.tsx
@@ -19,14 +19,14 @@ export function WishlistItem({ product, onRemoveClick, shopUrl }: Props) {
             variant="primary"
             target="_blank"
             href={`${shopUrl}/products/${product.handle}`}
-            inline-size="fill"
+            inlineSize="fill"
           >
             Buy now
           </s-button>
           <s-button
             variant="secondary"
             onClick={onRemoveClick}
-            inline-size="fill"
+            inlineSize="fill"
           >
             Remove
           </s-button>

--- a/extensions/wishlist-suggestions-inline/src/OrderListPageExtension.tsx
+++ b/extensions/wishlist-suggestions-inline/src/OrderListPageExtension.tsx
@@ -76,9 +76,9 @@ function OrderListPageExtension({
             title={product.title}
             price={product.priceRange.minVariantPrice}
             actions={
-              <s-box inline-size="100%">
+              <s-box inlineSize="100%">
                 <s-button
-                  inline-size="fill"
+                  inlineSize="fill"
                   variant="secondary"
                   onClick={() => {
                     addToWishlist(product.id);


### PR DESCRIPTION
I imagine some cursor autocomplete gone roque? 😅 

Broken
<img width="255" alt="image" src="https://github.com/user-attachments/assets/1edb2d63-9c2d-4908-a08a-60a8a34797ef" />


New
<img width="288" alt="image" src="https://github.com/user-attachments/assets/0d497c53-71a4-4b65-bc99-7f155b38774c" />

I'll do the same PR on the `workshop_outcome` branch
